### PR TITLE
Remove gulp-util and replace with plugin-error

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,5 @@
 var through     = require('through2');
-var PluginError = require('gulp-util').PluginError;
+var PluginError = require('plugin-error');
 
 // consts
 const PLUGIN_NAME = 'gulp-mincer';

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   },
   "homepage": "https://github.com/jisaacks/gulp-mincer",
   "dependencies": {
-    "gulp-util": "^3.0.2",
+    "plugin-error": "^1.0.1",
     "through2": "^0.6.3"
   }
 }


### PR DESCRIPTION
Fixes the deprecation warning for `gulp-util`.